### PR TITLE
Add qa parameter on activate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.mills.io/prologic/bitcask v1.0.2
 	github.com/aws/aws-sdk-go v1.40.45
 	github.com/flagship-io/flagship-common v0.0.19
-	github.com/flagship-io/flagship-proto v0.0.21
+	github.com/flagship-io/flagship-proto v0.0.22
 	github.com/go-kit/kit v0.12.0
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/flagship-io/flagship-common v0.0.19 h1:XHgek8I4w4WTu9z8sbfcJEfduvNgvg
 github.com/flagship-io/flagship-common v0.0.19/go.mod h1:fBqE2c4onD+V+0rs5IKugmQwowmmO2Af42DVoYVt36Y=
 github.com/flagship-io/flagship-proto v0.0.21 h1:zVFFRCHTOonXD1/xVrHvUShVF0UNuH5BXsWjaySJ5IA=
 github.com/flagship-io/flagship-proto v0.0.21/go.mod h1:Nv5epf8wbbAEx6sAnjPumFy+YQOClXyXlxZzUMUqidw=
+github.com/flagship-io/flagship-proto v0.0.22 h1:LN7WhIslDz2lmOsBH3T9F7V2QEfRbMby+W//mhvl0UI=
+github.com/flagship-io/flagship-proto v0.0.22/go.mod h1:Nv5epf8wbbAEx6sAnjPumFy+YQOClXyXlxZzUMUqidw=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/franela/goblin v0.0.0-20210519012713-85d372ac71e2/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -123,6 +123,7 @@ func Activate(context *connectors.DecisionContext) func(http.ResponseWriter, *ht
 				VariationID:     activateItem.Vaid,
 				Timestamp:       now.UnixNano() / 1000000,
 				PersistActivate: shouldPersistActivation,
+				QA:              activateItem.Qa,
 				QueueTime:       activateItem.Qt,
 			})
 		}

--- a/pkg/handlers/activate_test.go
+++ b/pkg/handlers/activate_test.go
@@ -106,6 +106,42 @@ func TestActivate(t *testing.T) {
 	assert.Equal(t, "anonymous_id", hitProcessor.TrackedHits.CampaignActivations[0].VisitorID)
 	assert.True(t, hitProcessor.TrackedHits.CampaignActivations[0].PersistActivate)
 
+	// activate simple with qa
+	body = `{
+		"cid": "env_id",
+		"aid": "anonymous_id",
+		"vid": "visitor_id",
+		"caid": "campaign_id",
+		"vaid": "variation_id",
+		"qa": true
+    }`
+	w = httptest.NewRecorder()
+
+	req = &http.Request{
+		URL:    url,
+		Body:   io.NopCloser(strings.NewReader(body)),
+		Method: "POST",
+	}
+
+	assignmentManager = assignments_managers.InitMemoryManager()
+	hitProcessor = &hits_processors.MockHitProcessor{}
+	context.EnvID = "env_id"
+	context.AssignmentsManager = assignmentManager
+	context.HitsProcessor = hitProcessor
+	Activate(context)(w, req)
+
+	resp = w.Result()
+	assert.Equal(t, 204, resp.StatusCode)
+
+	assert.Len(t, hitProcessor.TrackedHits.CampaignActivations, 1)
+	assert.Equal(t, "variation_id", hitProcessor.TrackedHits.CampaignActivations[0].VariationID)
+	assert.Equal(t, "campaign_id", hitProcessor.TrackedHits.CampaignActivations[0].CampaignID)
+	assert.Equal(t, "env_id", hitProcessor.TrackedHits.CampaignActivations[0].EnvID)
+	assert.Equal(t, "visitor_id", hitProcessor.TrackedHits.CampaignActivations[0].CustomerID)
+	assert.Equal(t, "anonymous_id", hitProcessor.TrackedHits.CampaignActivations[0].VisitorID)
+	assert.True(t, hitProcessor.TrackedHits.CampaignActivations[0].PersistActivate)
+	assert.True(t, hitProcessor.TrackedHits.CampaignActivations[0].QA)
+
 	// activate batch
 	body = `{
 		"cid": "env_id",

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -26,6 +26,7 @@ type CampaignActivation struct {
 	VariationID     string `json:"vaid"`
 	Timestamp       int64
 	PersistActivate bool
+	QA              bool  `json:"qa"`
 	QueueTime       int64 `json:"qt"`
 }
 
@@ -40,6 +41,7 @@ func (c *CampaignActivation) ToMap() map[string]interface{} {
 		"caid": c.CampaignID,
 		"vaid": c.VariationID,
 		"qt":   c.QueueTime,
+		"qa":   c.QA,
 		"t":    "CAMPAIGN",
 	}
 

--- a/pkg/models/model_test.go
+++ b/pkg/models/model_test.go
@@ -39,6 +39,7 @@ func TestCampaignActivationToMap(t *testing.T) {
 		"caid": "caid",
 		"vaid": "vaid",
 		"qt":   int64(100),
+		"qa":   false,
 		"t":    "CAMPAIGN",
 	}, obj)
 }


### PR DESCRIPTION
Add qa parameter as a body parameter in the /activate method, to be handled by the hit processor