### PR TITLE
feat: add EAI flags to extra response data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.23.3
 
 require (
 	github.com/aws/aws-sdk-go v1.40.45
-	github.com/flagship-io/flagship-common v0.0.21
-	github.com/flagship-io/flagship-proto v0.0.23
+	github.com/flagship-io/flagship-common v0.0.23
+	github.com/flagship-io/flagship-proto v0.0.24
 	github.com/go-kit/kit v0.12.0
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/flagship-io/flagship-common v0.0.21 h1:NZzdNVEt8hCtYGVxcpk8jxaqUuzA+b9ZOhMTEfF1udQ=
-github.com/flagship-io/flagship-common v0.0.21/go.mod h1:YGlDzICSf7Oav2W+/jy3xXqjILtk/6R1wFAfRkwrBLI=
-github.com/flagship-io/flagship-proto v0.0.23 h1:xt8SHsoLZwL0Bca1+tRrppCglUm+m/2f42tiUQUovn0=
-github.com/flagship-io/flagship-proto v0.0.23/go.mod h1:wmNh0bk497tmdkyiqk0iWMsohcw32cBIpJzNb4RI2S8=
+github.com/flagship-io/flagship-common v0.0.23 h1:7VFL13abw7SGOidA2U8q1+tag/fKpRlK9/cnJA79uOY=
+github.com/flagship-io/flagship-common v0.0.23/go.mod h1:BozH62CH7iYmQcxgnjpX5qAAtSbNJVzWenPIKDrrVTI=
+github.com/flagship-io/flagship-proto v0.0.24 h1:54wAOEo7xVsGumXkHTAQBs1vBXkcm4IJ5FJHIre4+w4=
+github.com/flagship-io/flagship-proto v0.0.24/go.mod h1:wmNh0bk497tmdkyiqk0iWMsohcw32cBIpJzNb4RI2S8=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/connectors/environment_loaders/cdn.go
+++ b/pkg/connectors/environment_loaders/cdn.go
@@ -136,12 +136,14 @@ func (l *CDNLoader) fetchEnvironment(envID string, APIKey string) error {
 	l.lock.Lock()
 	l.loadedEnvironment = &models.Environment{
 		Common: &common.Environment{
-			ID:                envID,
-			Campaigns:         campaigns,
-			IsPanic:           conf.Panic,
-			SingleAssignment:  conf.AccountSettings.Enabled1V1T,
-			UseReconciliation: conf.AccountSettings.EnabledXPC || conf.VisitorConsolidation,
-			CacheEnabled:      true,
+			ID:                   envID,
+			Campaigns:            campaigns,
+			IsPanic:              conf.Panic,
+			SingleAssignment:     conf.AccountSettings.Enabled1V1T,
+			UseReconciliation:    conf.AccountSettings.EnabledXPC || conf.VisitorConsolidation,
+			EaiCollectEnabled:    conf.AccountSettings.EaiCollectEnabled,
+			EaiActivationEnabled: conf.AccountSettings.EaiActivationEnabled,
+			CacheEnabled:         true,
 		},
 		HasIntegrations: false,
 	}

--- a/pkg/handlers/campaigns.go
+++ b/pkg/handlers/campaigns.go
@@ -37,9 +37,11 @@ func Campaigns(context *connectors.DecisionContext) func(http.ResponseWriter, *h
 
 func toAccountSettings(e *models.Environment) *decision_response.AccountSettings {
 	return &decision_response.AccountSettings{
-		EnabledXPC:      e.Common.UseReconciliation,
-		Enabled1V1T:     e.Common.SingleAssignment,
-		Troubleshooting: e.Common.Troubleshooting,
+		EnabledXPC:           e.Common.UseReconciliation,
+		Enabled1V1T:          e.Common.SingleAssignment,
+		EaiCollectEnabled:    e.Common.EaiCollectEnabled,
+		EaiActivationEnabled: e.Common.EaiActivationEnabled,
+		Troubleshooting:      e.Common.Troubleshooting,
 	}
 }
 


### PR DESCRIPTION
Add the following EAI flags to the response of /campaign endpoint when called with `extras=accountSettings` : 
- EaiCollectEnabled
- EaiActivationEnabled